### PR TITLE
AutoUpdateDialog初始化时，mw_one作为空指针使用

### DIFF
--- a/autoupdatedialog.cpp
+++ b/autoupdatedialog.cpp
@@ -19,7 +19,9 @@ AutoUpdateDialog::AutoUpdateDialog(QWidget* parent)
   ui->progressBar->setTextVisible(false);
   Init();
   tempDir = QDir::homePath() + "/tempocat/";
-  qobject_cast<MainWindow *>(parent)->deleteDirfile(tempDir);
+  MainWindow *mainWindow = qobject_cast<MainWindow *>(parent);
+  if (mainWindow)
+      mainWindow->deleteDirfile(tempDir);
   ui->textEdit->setVisible(false);
 }
 

--- a/autoupdatedialog.cpp
+++ b/autoupdatedialog.cpp
@@ -19,7 +19,7 @@ AutoUpdateDialog::AutoUpdateDialog(QWidget* parent)
   ui->progressBar->setTextVisible(false);
   Init();
   tempDir = QDir::homePath() + "/tempocat/";
-  mw_one->deleteDirfile(tempDir);
+  qobject_cast<MainWindow *>(parent)->deleteDirfile(tempDir);
   ui->textEdit->setVisible(false);
 }
 


### PR DESCRIPTION
由于AutoUpdateDialog对象是在MainWindow的构造函数中初始化的，因此在AutoUpdateDialog的构造函数中使用mw_one时，mw_one为空