### PR TITLE
Update READMe.md to fix the Guides link 404 

### DIFF
--- a/READMe.md
+++ b/READMe.md
@@ -27,9 +27,9 @@ Besides beeing a plist Configurator it can do much more:
 
 ## Guides
 
-* [Updating OpenCore and Kexts with OCAT (by 5T33Z0)](https://github.com/5T33Z0/OC-Little-Translated/blob/main/D_Updating_OpenCore/README.md)
-* Pre-selected plug-in content for Intel CPU Quirks is provided and maintained by 5T33Z0. [Details](https://github.com/5T33Z0/OC-Little-Translated/tree/main/F_Desktop_EFIs/preset)
-* Intel CPU BaseConfigs plug-in package provided and maintained by 5T33Z0. [Details](https://github.com/5T33Z0/OC-Little-Translated/tree/main/F_Desktop_EFIs)
+* [Updating OpenCore and Kexts with OCAT (by 5T33Z0)](https://github.com/5T33Z0/OC-Little-Translated/blob/main/Content/D_Updating_OpenCore/README.md)
+* Pre-selected plug-in content for Intel CPU Quirks is provided and maintained by 5T33Z0. [Details](https://github.com/5T33Z0/OC-Little-Translated/tree/main/Content/F_Desktop_EFIs/preset)
+* Intel CPU BaseConfigs plug-in package provided and maintained by 5T33Z0. [Details](https://github.com/5T33Z0/OC-Little-Translated/tree/main/Content/F_Desktop_EFIs)
 * [OpenCore Auxiliary Tools User's Guide (by chriswayg)](https://chriswayg.gitbook.io/opencore-visual-beginners-guide/oc_auxiliary_tools)
 
 


### PR DESCRIPTION
Update READMe.md to be compatible with the Content directory of the OC-Little-Translated repository 

+ Success: https://github.com/5T33Z0/OC-Little-Translated/blob/main/Content/D_Updating_OpenCore/README.md

+ Error: https://github.com/5T33Z0/OC-Little-Translated/blob/main/D_Updating_OpenCore/README.md

<img width="2973" height="1265" alt="b82f1062-5fd6-48bb-80e1-58eca9eb9eb9" src="https://github.com/user-attachments/assets/34ebe7f9-c11b-483e-b321-ff5ff2bf2a8b" />
